### PR TITLE
Fix git URL validation error

### DIFF
--- a/pootle_fs_git/getters.py
+++ b/pootle_fs_git/getters.py
@@ -10,7 +10,7 @@ from pootle.core.delegate import response, state
 from pootle.core.plugin import getter
 
 from pootle_fs.delegate import (
-    fs_file, fs_finder, fs_matcher, fs_resources)
+    fs_file, fs_finder, fs_matcher, fs_resources, fs_url_validator)
 from pootle_fs.matcher import FSPathMatcher
 from pootle_fs.resources import FSProjectResources
 from pootle_fs.response import ProjectFSResponse
@@ -20,6 +20,7 @@ from .files import GitFSFile
 from .finder import GitTranslationFileFinder
 from .plugin import GitPlugin
 from .state import GitProjectState
+from .validators import GitFSUrlValidator
 
 
 @getter(state, sender=GitPlugin)
@@ -60,3 +61,7 @@ def fs_file_getter(**kwargs):
 @getter(fs_finder, sender=GitPlugin)
 def fs_finder_getter(**kwargs):
     return GitTranslationFileFinder
+
+@getter(fs_url_validator, sender=GitPlugin)
+def fs_url_validator_getter(**kwargs_):
+    return GitFSUrlValidator


### PR DESCRIPTION
It was not possible to enter a URL for a project. The server process showd up with this traceback:

```
Traceback (most recent call last):
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/django/utils/decorators.py", line 185, in inner
    return func(*args, **kwargs)
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/pootle/core/views/mixins.py", line 30, in dispatch
    **kwargs)
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/pootle/core/views/api.py", line 120, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/pootle/core/views/api.py", line 184, in put
    if form.is_valid():
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/django/forms/forms.py", line 169, in is_valid
    return self.is_bound and not self.errors
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/django/forms/forms.py", line 161, in errors
    self.full_clean()
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/django/forms/forms.py", line 371, in full_clean
    self._clean_form()
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/django/forms/forms.py", line 398, in _clean_form
    cleaned_data = self.clean()
  File "/home/pootle/pootle/env/local/lib/python2.7/site-packages/pootle/apps/pootle_app/forms.py", line 126, in clean
    validator = fs_url_validator.get(plugin)()
TypeError: 'NoneType' object is not callable
```